### PR TITLE
Fixes #1 improve scan flow

### DIFF
--- a/Bookmind.xcodeproj/project.pbxproj
+++ b/Bookmind.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		741913082B4DF95400F8CADB /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 741913072B4DF95400F8CADB /* README.md */; };
-		742C63D82B5720D00047FED7 /* OpenLibraryBookTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C63D72B5720D00047FED7 /* OpenLibraryBookTests.swift */; };
+		742C63D82B5720D00047FED7 /* OpenLibraryEditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C63D72B5720D00047FED7 /* OpenLibraryEditionTests.swift */; };
 		742C63DA2B58157A0047FED7 /* OpenLibraryBookSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C63D92B58157A0047FED7 /* OpenLibraryBookSearch.swift */; };
 		742C63DD2B5826450047FED7 /* OpenLibraryEdition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C63DC2B5826450047FED7 /* OpenLibraryEdition.swift */; };
 		742C63E12B582B0D0047FED7 /* BookSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C63E02B582B0D0047FED7 /* BookSearch.swift */; };
@@ -80,7 +80,7 @@
 
 /* Begin PBXFileReference section */
 		741913072B4DF95400F8CADB /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		742C63D72B5720D00047FED7 /* OpenLibraryBookTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenLibraryBookTests.swift; sourceTree = "<group>"; };
+		742C63D72B5720D00047FED7 /* OpenLibraryEditionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenLibraryEditionTests.swift; sourceTree = "<group>"; };
 		742C63D92B58157A0047FED7 /* OpenLibraryBookSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenLibraryBookSearch.swift; sourceTree = "<group>"; };
 		742C63DC2B5826450047FED7 /* OpenLibraryEdition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenLibraryEdition.swift; sourceTree = "<group>"; };
 		742C63E02B582B0D0047FED7 /* BookSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSearch.swift; sourceTree = "<group>"; };
@@ -242,7 +242,7 @@
 				EE9018992C0FB84100B6990A /* WorkTests.swift */,
 				74FE52172B5621A300D1B9DD /* ISBNTests.swift */,
 				74B8DF862B5CA3F100D2F818 /* OpenLibraryAuthorTests.swift */,
-				742C63D72B5720D00047FED7 /* OpenLibraryBookTests.swift */,
+				742C63D72B5720D00047FED7 /* OpenLibraryEditionTests.swift */,
 				74B8DF882B5D670100D2F818 /* OpenLibraryWorkTests.swift */,
 			);
 			path = BookmindTests;
@@ -483,7 +483,7 @@
 				EE2B1C302C0F9A6800C332F9 /* AuthorTests.swift in Sources */,
 				EE89B4E92C10C47900827F8A /* EditionTests.swift in Sources */,
 				74FE52182B5621A300D1B9DD /* ISBNTests.swift in Sources */,
-				742C63D82B5720D00047FED7 /* OpenLibraryBookTests.swift in Sources */,
+				742C63D82B5720D00047FED7 /* OpenLibraryEditionTests.swift in Sources */,
 				74B8DF892B5D670100D2F818 /* OpenLibraryWorkTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -717,9 +717,13 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = uncled.BookmindTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Bookmind.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Bookmind";
 			};
 			name = Debug;
@@ -737,9 +741,13 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = uncled.BookmindTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Bookmind.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Bookmind";
 			};
 			name = Release;
@@ -756,9 +764,13 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = uncled.BookmindUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 				TEST_TARGET_NAME = Bookmind;
 			};
 			name = Debug;
@@ -775,9 +787,13 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = uncled.BookmindUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 				TEST_TARGET_NAME = Bookmind;
 			};
 			name = Release;

--- a/Bookmind/Entity/OwnState.swift
+++ b/Bookmind/Entity/OwnState.swift
@@ -21,7 +21,7 @@ enum OwnState: String, Codable, CaseIterable {
 			case .own:
 				"Own"
 			case .none:
-				"Won't own"
+				"Don't want"
 		}
 	}
 }

--- a/Bookmind/Entity/ReadState.swift
+++ b/Bookmind/Entity/ReadState.swift
@@ -9,6 +9,7 @@
 enum ReadState: Int, Codable, CaseIterable {
 	case read
 	case want
+	case reading
 	case maybe
 	case none
 
@@ -18,6 +19,8 @@ enum ReadState: Int, Codable, CaseIterable {
 				"Might read"
 			case .want:
 				"Want to read"
+			case .reading:
+				"Reading"
 			case .read:
 				"Have read"
 			case .none:

--- a/Bookmind/Scan/ScanModel.swift
+++ b/Bookmind/Scan/ScanModel.swift
@@ -24,7 +24,7 @@ final class ScanModel: ObservableObject {
 		 /// A message helping the user understand why the scanner isn't working.
 		 case failed(String)
 		 /// The scanner found an array of possible ISBN codes.
-		 case found([ISBN])
+		 case found(ISBN)
 		 /// The scanner is working but has not yet found a possible ISBN.
 		 case searching
 	 }
@@ -32,7 +32,7 @@ final class ScanModel: ObservableObject {
 	struct Preview {
 		static let searching = ScanModel()
 		static var failed = ScanModel(state: .failed("Could not open scanner"))
-		static var found = ScanModel(state: .found([ISBN("9781841498584")!]))
+		static var found = ScanModel(state: .found(ISBN.Preview.isbn10!))
 	}
 }
 
@@ -40,11 +40,11 @@ extension ScanModel: CustomStringConvertible {
 	var description: String {
 		switch self.state {
 			case .searching:
-				return "Center the camera on an ISBN number or bar code"
+				return "Center the camera on an ISBN number, either on the back cover or the copyright page."
 			case .failed(let error):
 				return error
-			case .found(let codes):
-				return "Searching for \(codes.joined())"
+			case .found(let isbn):
+				return "Searching for \(isbn)"
 		}
 	}
 }

--- a/Bookmind/Scan/ScanScreen.swift
+++ b/Bookmind/Scan/ScanScreen.swift
@@ -65,8 +65,8 @@ struct ScanScreen: View {
 	}
 	
 	private func scanModelChanged() {
-		if case .found(let results) = self.scanModel.state {
-			self.searchModel.search(results: results)
+		if case .found(let isbn) = self.scanModel.state {
+			self.searchModel.search(isbn)
 		}
 	}
 	

--- a/Bookmind/Scan/ScanView.swift
+++ b/Bookmind/Scan/ScanView.swift
@@ -19,10 +19,8 @@ struct ScanView: UIViewControllerRepresentable {
 	}
 	
 	func makeUIViewController(context: Context) -> DataScannerViewController {
-		let controller = DataScannerViewController(recognizedDataTypes: [
-			.barcode(symbologies: [.ean8, .ean13]),
-			.text()
-		], recognizesMultipleItems: true, isHighlightingEnabled: true)
+		let controller = DataScannerViewController(recognizedDataTypes: [.text()],
+			qualityLevel: .fast, recognizesMultipleItems: true, isHighlightingEnabled: true)
 		controller.view.backgroundColor = .background
 		controller.delegate = context.coordinator
 		context.coordinator.start(scanner: controller)

--- a/Bookmind/Scan/SearchModel.swift
+++ b/Bookmind/Scan/SearchModel.swift
@@ -21,20 +21,13 @@ final class SearchModel: ObservableObject {
 		self.result = result
 	}
 	
-	func search(results: [ISBN]) {
-		let newSearches = results.map { $0.digitString }
-		for isbn in newSearches {
-			self.search(isbn: isbn)
-		}
-	}
-	
-	private func search(isbn: String) {
+	func search(_ scanResult: ISBN) {
 		// don't seach again for an isbn we've already checked
-		if searches.contains(where: { $0.isbn == isbn } ) {
+		if searches.contains(where: { $0.isbn == scanResult.digitString } ) {
 			return
 		}
 		
-		let search = OpenLibraryBookSearch(isbn: isbn)
+		let search = OpenLibraryBookSearch(isbn: scanResult.digitString)
 		self.searches.append(search)
 		self.cancellables.append(search.$result
 			.subscribe(on: DispatchQueue.global(qos: .background))

--- a/BookmindTests/ISBNTests.swift
+++ b/BookmindTests/ISBNTests.swift
@@ -9,45 +9,69 @@ import XCTest
 @testable import Bookmind
 
 final class ISBNTests: XCTestCase {
-	static let sbn = "SBN 425-03071-7"
-	static let isbn10 = "ISBN 0-441-78754-1"
-	static let isbn13 = "ISBN 978-3-16-148410-0"
-	
 	func testEmpty() {
 		let isbn = ISBN("")
 		XCTAssertNil(isbn)
 	}
 	
 	func testInvalidLength() {
+		var isbn = ISBN("SBN 425-0")
+		XCTAssertNil(isbn)
+		
+		isbn = ISBN("ISBN 425-0")
+		XCTAssertNil(isbn)
+		
+		isbn = ISBN("ISBN: 425-0")
+		XCTAssertNil(isbn)
+		
+		isbn = ISBN("SBN 425-0978-3-16-148410-0")
+		XCTAssertNil(isbn)
+		
+		isbn = ISBN("ISBN 425-0978-3-16-148410-0")
+		XCTAssertNil(isbn)
+		
+		isbn = ISBN("ISBN: 425-0978-3-16-148410-0")
+		XCTAssertNil(isbn)
+	}
+	
+	func testMissing() {
 		let isbn = ISBN("Stormbringer by Michael Moorcock")
 		XCTAssertNil(isbn)
 	}
-	
-	func testInvalidSuffix() {
-		let isbn = ISBN(Self.sbn + " suffix")
-		XCTAssertNil(isbn)
+
+	func testSuffix() {
+		let isbn = ISBN.Preview.prefix
+		XCTAssertEqual(isbn?.displayString, "425-03071-7")
+		XCTAssertEqual(isbn?.digitString, "425030717")
 	}
 	
-	func testInvalidPrefix() {
-		let isbn = ISBN("prefix " + Self.sbn)
-		XCTAssertNil(isbn)
+	func testPrefix() {
+		let isbn = ISBN.Preview.suffix
+		XCTAssertEqual(isbn?.displayString, "425-03071-7")
+		XCTAssertEqual(isbn?.digitString, "425030717")
 	}
 	
 	func testSBN() {
-		let isbn = ISBN(Self.sbn)
-		XCTAssertEqual(isbn?.displayString, Self.sbn)
+		let isbn = ISBN.Preview.sbn
+		XCTAssertEqual(isbn?.displayString, "425-03071-7")
 		XCTAssertEqual(isbn?.digitString, "425030717")
 	}
 	
 	func testISBN10() {
-		let isbn = ISBN(Self.isbn10)
-		XCTAssertEqual(isbn?.displayString, Self.isbn10)
+		let isbn = ISBN.Preview.isbn10
+		XCTAssertEqual(isbn?.displayString, "0-441-78754-1")
 		XCTAssertEqual(isbn?.digitString, "0441787541")
 	}
 	
 	func testISBN13() {
-		let isbn = ISBN(Self.isbn13)
-		XCTAssertEqual(isbn?.displayString, Self.isbn13)
+		let isbn = ISBN.Preview.isbn13
+		XCTAssertEqual(isbn?.displayString, "978-3-16-148410-0")
 		XCTAssertEqual(isbn?.digitString, "9783161484100")
+	}
+	
+	func testCopyright() {
+		let isbn = ISBN.Preview.copyright
+		XCTAssertEqual(isbn?.displayString, "0-441-78754-1")
+		XCTAssertEqual(isbn?.digitString, "0441787541")
 	}
 }

--- a/BookmindTests/OpenLibraryEditionTests.swift
+++ b/BookmindTests/OpenLibraryEditionTests.swift
@@ -1,5 +1,5 @@
 //
-//  OpenLibraryBookTests.swift
+//  OpenLibraryEditionTests.swift
 //  BookmindTests
 //
 //  Created by Dave Ruest on 1/16/24.
@@ -8,7 +8,7 @@
 import XCTest
 @testable import Bookmind
 
-final class OpenLibraryBookTests: XCTestCase {
+final class OpenLibraryEditionTests: XCTestCase {
 	private let decoder = JSONDecoder()
 	
 	// https://openlibrary.org/isbn/9780307352156.json


### PR DESCRIPTION
Removed bar code from recognized scan types, and from scan coordinator handling code. Noticed in testing that we will rarely have more than 1 scanned ISBN, so changed search result to a single ISBN value from an array.

Updated ISBN tests. Moved test artifacts to ISBN preview struct where they can be shared by tests and previews. Added a new ISBN preview with an "ISBN:" prefix that appeared on a copyright page.

A few other small changes. Updated the scanning state message to de-emphasize bar codes and mention the ISBN on the copyright page. Added a "reading" state.