### PR TITLE
Fixes #12 scanning "ISBN-13:" and "ISBN-10:" prefixes

### DIFF
--- a/Bookmind/Scan/ISBN.swift
+++ b/Bookmind/Scan/ISBN.swift
@@ -41,14 +41,7 @@ struct ISBN: Equatable {
 		guard string.count >= 9 else { return nil }
 		
 		let words = string.components(separatedBy: CharacterSet.whitespacesAndNewlines)
-		var index = words.firstIndex(of: "ISBN:")
-		if index == nil {
-			index = words.firstIndex(of: "ISBN")
-		}
-		if index == nil {
-			index = words.firstIndex(of: "SBN")
-		}
-		guard let index else { return nil }
+		guard let index = firstPrefix(in: words) else { return nil }		
 		guard words.count > index + 1 else { return nil }
 		
 		let code = words[index + 1]
@@ -57,12 +50,24 @@ struct ISBN: Equatable {
 		return code
 	}
 	
+	private static func firstPrefix(in words: [String]) -> Int? {
+		// yeah this is a bit ridiculous for if/else cases
+		for prefix in ["ISBN-13:", "ISBN-10:", "ISBN:", "ISBN", "SBN"] {
+			if let index = words.firstIndex(of: prefix) {
+				return index
+			}
+		}
+		return nil
+	}
+	
 	struct Preview {
 		static let prefix = ISBN("text before isbn number SBN 425-03071-7")
 		static let suffix = ISBN("SBN 425-03071-7 text after isbn number")
 		static let sbn = ISBN("SBN 425-03071-7")
 		static let isbn10 = ISBN("ISBN 0-441-78754-1")
 		static let isbn13 = ISBN("ISBN 978-3-16-148410-0")
+		static let isbn_10 = ISBN("ISBN-10: 0-7582-8393-8")
+		static let isbn_13 = ISBN("ISBN-13: 978-0-7783-3027-1")
 		static let copyright = ISBN("ISBN: 0-441-78754-1")
 	}
 }

--- a/BookmindTests/ISBNTests.swift
+++ b/BookmindTests/ISBNTests.swift
@@ -58,15 +58,23 @@ final class ISBNTests: XCTestCase {
 	}
 	
 	func testISBN10() {
-		let isbn = ISBN.Preview.isbn10
+		var isbn = ISBN.Preview.isbn10
 		XCTAssertEqual(isbn?.displayString, "0-441-78754-1")
 		XCTAssertEqual(isbn?.digitString, "0441787541")
+		
+		isbn = ISBN.Preview.isbn_10
+		XCTAssertEqual(isbn?.displayString, "0-7582-8393-8")
+		XCTAssertEqual(isbn?.digitString, "0758283938")
 	}
 	
 	func testISBN13() {
-		let isbn = ISBN.Preview.isbn13
+		var isbn = ISBN.Preview.isbn13
 		XCTAssertEqual(isbn?.displayString, "978-3-16-148410-0")
 		XCTAssertEqual(isbn?.digitString, "9783161484100")
+		
+		isbn = ISBN.Preview.isbn_13
+		XCTAssertEqual(isbn?.displayString, "978-0-7783-3027-1")
+		XCTAssertEqual(isbn?.digitString, "9780778330271")
 	}
 	
 	func testCopyright() {


### PR DESCRIPTION
Added new handling and tests for these cases. Tidied up the handling to use an array of expected prefixes. Less code, reads better, and makes it easy to add another prefix.