### PR TITLE
Fixes #19 scan ISBN numbers starting with SBN-

### DIFF
--- a/Bookmind/Scan/ISBN.swift
+++ b/Bookmind/Scan/ISBN.swift
@@ -41,13 +41,13 @@ struct ISBN: Equatable {
 		guard string.count >= 9 else { return nil }
 		
 		let words = string.components(separatedBy: CharacterSet.whitespacesAndNewlines)
-		guard let index = firstPrefix(in: words) else { return nil }		
-		guard words.count > index + 1 else { return nil }
+		if let code = words.firstCodeAfterKeyword() {
+			return code
+		} else if let code = words.firstCodeWithPrefix() {
+			return code
+		}
 		
-		let code = words[index + 1]
-		guard code.count > 9 && code.count < 20 else { return nil }
-		
-		return code
+		return nil
 	}
 	
 	private static func firstPrefix(in words: [String]) -> Int? {
@@ -64,10 +64,39 @@ struct ISBN: Equatable {
 		static let prefix = ISBN("text before isbn number SBN 425-03071-7")
 		static let suffix = ISBN("SBN 425-03071-7 text after isbn number")
 		static let sbn = ISBN("SBN 425-03071-7")
+		static let sbn_ = ISBN("SBN-425-03585-9") // really?
 		static let isbn10 = ISBN("ISBN 0-441-78754-1")
 		static let isbn13 = ISBN("ISBN 978-3-16-148410-0")
 		static let isbn_10 = ISBN("ISBN-10: 0-7582-8393-8")
 		static let isbn_13 = ISBN("ISBN-13: 978-0-7783-3027-1")
 		static let copyright = ISBN("ISBN: 0-441-78754-1")
+	}
+}
+
+private extension Array where Element == String {
+	func firstCodeAfterKeyword() -> String? {
+		for keyword in ["ISBN-13:", "ISBN-10:", "ISBN:", "ISBN", "SBN"] {
+			if let index = self.firstIndex(of: keyword) {
+				if self.count > index + 1 {
+					let code = self[index + 1]
+					if code.count > 9 || code.count < 20 {
+						return code
+					}
+				}
+			}
+		}
+		return nil
+	}
+	
+	func firstCodeWithPrefix() -> String? {
+		for prefix in ["SBN-"] {
+			if let word = self.first(where: { $0.hasPrefix(prefix) }) {
+				let code = String(word.dropFirst(prefix.count))
+				if code.count > 9 || code.count < 20 {
+					return code
+				}
+			}
+		}
+		return nil
 	}
 }

--- a/BookmindTests/ISBNTests.swift
+++ b/BookmindTests/ISBNTests.swift
@@ -57,6 +57,12 @@ final class ISBNTests: XCTestCase {
 		XCTAssertEqual(isbn?.digitString, "425030717")
 	}
 	
+	func testSBN_() {
+		let isbn = ISBN.Preview.sbn_
+		XCTAssertEqual(isbn?.displayString, "425-03585-9")
+		XCTAssertEqual(isbn?.digitString, "425035859")
+	}
+
 	func testISBN10() {
 		var isbn = ISBN.Preview.isbn10
 		XCTAssertEqual(isbn?.displayString, "0-441-78754-1")


### PR DESCRIPTION
Added a whole other method to check for prefixes that don't have a space between them and the ISBN code. It's starting to sound like a good idea to re-introduce bar code scanning.