### PR TITLE
Fixes #22 author name edit not saved

### DIFF
--- a/Bookmind.xcodeproj/project.pbxproj
+++ b/Bookmind.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		EE8F34EE2C232DA0001C7A84 /* WorkListLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8F34ED2C232DA0001C7A84 /* WorkListLabel.swift */; };
 		EE8F41B02C3048B1007A22F5 /* SearchRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8F41AF2C3048B1007A22F5 /* SearchRouter.swift */; };
 		EE8F41B32C331405007A22F5 /* InsertBookModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8F41B22C331405007A22F5 /* InsertBookModel.swift */; };
+		EE8F41B52C3447C0007A22F5 /* BookTextFieldModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8F41B42C3447C0007A22F5 /* BookTextFieldModifier.swift */; };
 		EE90189A2C0FB84100B6990A /* WorkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE9018992C0FB84100B6990A /* WorkTests.swift */; };
 		EEBB7CE52C17AD6E00C96389 /* Book.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBB7CE42C17AD6E00C96389 /* Book.swift */; };
 		EEC762A32C1338650074066E /* BookStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC762A22C1338650074066E /* BookStyle.swift */; };
@@ -140,6 +141,7 @@
 		EE8F34ED2C232DA0001C7A84 /* WorkListLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkListLabel.swift; sourceTree = "<group>"; };
 		EE8F41AF2C3048B1007A22F5 /* SearchRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRouter.swift; sourceTree = "<group>"; };
 		EE8F41B22C331405007A22F5 /* InsertBookModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsertBookModel.swift; sourceTree = "<group>"; };
+		EE8F41B42C3447C0007A22F5 /* BookTextFieldModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookTextFieldModifier.swift; sourceTree = "<group>"; };
 		EE9018992C0FB84100B6990A /* WorkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkTests.swift; sourceTree = "<group>"; };
 		EEBB7CE42C17AD6E00C96389 /* Book.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Book.swift; sourceTree = "<group>"; };
 		EEC762A22C1338650074066E /* BookStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookStyle.swift; sourceTree = "<group>"; };
@@ -322,6 +324,7 @@
 				745D920A2B4B055500A62F89 /* BookGroupModifier.swift */,
 				747892AB2B87F815004ABDEF /* BookListModifier.swift */,
 				EEC762A62C13461F0074066E /* BookPickerModifier.swift */,
+				EE8F41B42C3447C0007A22F5 /* BookTextFieldModifier.swift */,
 				EEC762A22C1338650074066E /* BookStyle.swift */,
 				EE7F7B2B2C24E1B400548AB9 /* CoverFetchModifier.swift */,
 				EE0CAC6E2C270F9900B90B5B /* LibraryBackgroundView.swift */,
@@ -459,6 +462,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EE8F41B52C3447C0007A22F5 /* BookTextFieldModifier.swift in Sources */,
 				742C63DA2B58157A0047FED7 /* OpenLibraryBookSearch.swift in Sources */,
 				EEC762A32C1338650074066E /* BookStyle.swift in Sources */,
 				745D920B2B4B055500A62F89 /* BookGroupModifier.swift in Sources */,

--- a/Bookmind/Browse/AuthorScreen.swift
+++ b/Bookmind/Browse/AuthorScreen.swift
@@ -13,7 +13,7 @@ struct AuthorScreen: View {
 	/// The author whose name and works will be shown.
 	@State var author: Author
 	/// Updated by the editable modifier when edit mode changes.
-	@State private var isEditing = false
+	@State var isEditing = false
 	/// Core data storage, used to delete editions.
 	@EnvironmentObject private var storage: StorageModel
 	/// The dismiss environment variable, used to close the screen if
@@ -27,16 +27,16 @@ struct AuthorScreen: View {
 			VStack(alignment: .leading, spacing: 8.0) {
 				Group {
 					if self.isEditing {
-						TextField("Name", text: self.$author.name, axis: .vertical)
-							.textFieldStyle(.roundedBorder)
-							.border(Color.accentColor, width: 1.0)
+						TextField("First Name", text: self.$author.firstName, axis: .vertical)
+							.bookTextFieldStyle()
+						TextField("Last Name", text: self.$author.lastName, axis: .vertical)
+							.bookTextFieldStyle()
+							.fontWeight(.bold)
 					} else {
 						Text("\(self.author.firstName) **\(self.author.lastName)**")
 							.frame(alignment: .leading)
 					}
 				}
-				.padding(.horizontal)
-				.animation(.smooth, value: self.isEditing)
 				.font(.title)
 				List {
 					// The "self.author.books" here lazy loads books
@@ -62,19 +62,13 @@ struct AuthorScreen: View {
 					}
 				}
 			}
+			.padding()
+			.animation(.smooth, value: self.isEditing)
 		}
 		.navigationBarTitleDisplayMode(.inline)
-		.editable(self.$isEditing) {
-			self.editModeChanged()
-		}
+		.editable(self.$isEditing)
 		.toolbar {
 			EditButton()
-		}
-	}
-	
-	private func editModeChanged() {
-		if !self.isEditing {
-			self.author.nameChanged()
 		}
 	}
 	
@@ -107,7 +101,7 @@ struct AuthorScreen: View {
 	let storage = StorageModel(preview: true)
 	let book = storage.insert(book: Book.Preview.quiet)
 	return NavigationStack {
-		AuthorScreen(author: book.authors.first!)
+		AuthorScreen(author: book.authors.first!, isEditing: true)
 	}
 	.modelContainer(storage.container)
 	.environmentObject(CoverModel())

--- a/Bookmind/Browse/LibraryScreen.swift
+++ b/Bookmind/Browse/LibraryScreen.swift
@@ -15,7 +15,7 @@ import SwiftUI
 /// book by title, if you forget the author name...
 struct LibraryScreen: View {
 	@EnvironmentObject var storage: StorageModel
-	@Query(sort: \Author.lastName, order: .forward) var authors: [Author]
+	@Query(sort: [SortDescriptor(\Author.lastName, comparator: .localizedStandard)]) var authors: [Author]
 	
 	var body: some View {
 		List {
@@ -35,7 +35,6 @@ struct LibraryScreen: View {
 		}
 		.listStyle(.plain)
 		.listRowSeparatorTint(.accent)
-//		.background(Color(.background))
 		.toolbar {
 			EditButton()
 		}

--- a/Bookmind/Entity/Author.swift
+++ b/Bookmind/Entity/Author.swift
@@ -14,7 +14,9 @@ import SwiftData
 /// restarts. The next big step for author will be cloud storage where
 /// the author will persist across devices.
 @Model final class Author {
-	var name: String
+	var name: String {
+		self.firstName + " " + self.lastName
+	}
 	var firstName: String
 	var lastName: String
 	/// The unique identifier for the author.
@@ -27,15 +29,8 @@ import SwiftData
 
 	init(olid: String, name: String, books: [Work] = []) {
 		self.olid = olid
-		self.name = name
 		self.books = books
 		
-		var splits = name.split(separator: " ")
-		self.lastName = String(splits.removeLast())
-		self.firstName = splits.joined(separator: " ")
-	}
-	
-	func nameChanged() {
 		var splits = name.split(separator: " ")
 		self.lastName = String(splits.removeLast())
 		self.firstName = splits.joined(separator: " ")

--- a/Bookmind/Scan/ScanModel.swift
+++ b/Bookmind/Scan/ScanModel.swift
@@ -42,11 +42,11 @@ extension ScanModel: CustomStringConvertible {
 	var description: String {
 		switch self.state {
 		case .searching:
-			return "Wait for the camera to focus on an ISBN number. Make sure \"ISBN\" and the whole number are visible."
+			return "Focus on an ISBN number for a few seconds. Make sure \"ISBN\" and the whole number are visible."
 		case .failed(let error):
 			return error
 		case .foundText:
-			return "Trouble scanning? The copyright page may have a larger, clearer font. You can also type an ISBN in search."
+			return "Trouble scanning? The copyright page may have a larger, clearer font. Or tap search to type in the number."
 		case .found(let isbn):
 			return "Searching for \(isbn.displayString)"
 		}

--- a/Bookmind/Search/SearchProgressView.swift
+++ b/Bookmind/Search/SearchProgressView.swift
@@ -44,7 +44,8 @@ struct SearchProgressView: View {
 					.bookGroupStyle()
 					.multilineTextAlignment(.center)
 			} else {
-				EmptyView()
+				// now necessary for images to appear in preview?
+				Text("")
 			}
 		}
 		.onChange(of: self.result, initial: true) {
@@ -82,7 +83,9 @@ struct SearchProgressView: View {
 		Color(.systemIndigo)
 			.ignoresSafeArea()
 		VStack(spacing: 16.0) {
-			SearchProgressView(result: .constant(BookSearch.Preview.failed), 
+			SearchProgressView(result: .constant(nil),
+							   router: SearchRouter())
+			SearchProgressView(result: .constant(BookSearch.Preview.failed),
 							   router: SearchRouter())
 			SearchProgressView(result: .constant(BookSearch.Preview.searching),
 							   router: SearchRouter())
@@ -95,4 +98,5 @@ struct SearchProgressView: View {
 		}
 		.padding()
 	}
+	.environmentObject(CoverModel())
 }

--- a/Bookmind/Search/SearchScreen.swift
+++ b/Bookmind/Search/SearchScreen.swift
@@ -51,12 +51,11 @@ struct SearchScreen: View {
 									   router: self.router)
 				}
 				TextField("ISBN", text: self.$searchText)
+					.bookTextFieldStyle()
 					.keyboardType(.numbersAndPunctuation)
 					.autocorrectionDisabled()
 					.submitLabel(.search)
 					.focused(self.$showKeyboard)
-					.textFieldStyle(.roundedBorder)
-					.border(Color.accentColor, width: 1.0)
 					.onSubmit {
 						self.searchTapped()
 					}
@@ -93,7 +92,6 @@ struct SearchScreen: View {
 	NavigationStack {
 		SearchScreen(router: SearchRouter(), searchModel: SearchModel.Preview.quiet)
 	}
-	.modelContainer(StorageModel.preview.container)
 	.environmentObject(CoverModel())
 }
 
@@ -101,6 +99,5 @@ struct SearchScreen: View {
 	NavigationStack {
 		SearchScreen(router: SearchRouter(), searchModel: SearchModel.Preview.legend)
 	}
-	.modelContainer(StorageModel.preview.container)
 	.environmentObject(CoverModel())
 }

--- a/Bookmind/Style/BookButtonModifier.swift
+++ b/Bookmind/Style/BookButtonModifier.swift
@@ -42,7 +42,7 @@ extension View {
 	ZStack {
 		Color(.systemIndigo)
 			.ignoresSafeArea()
-		VStack(spacing: 16.0) {
+		VStack {
 			Label("Scan Book", systemImage: "camera.fill")
 				.bookButtonStyle()
 			Label("Save Book", systemImage: "square.and.arrow.down.fill")

--- a/Bookmind/Style/BookTextFieldModifier.swift
+++ b/Bookmind/Style/BookTextFieldModifier.swift
@@ -1,0 +1,56 @@
+//
+//  BookTextFieldModifier.swift
+//  Bookmind
+//
+//  Created by Dave Ruest on 2024-07-02.
+//
+
+import SwiftUI
+
+/// BookTextFieldModifier defines an app specific text field appearance.
+/// Frame size is shared with other buttons and groups, so padding, height
+/// and widths are similar when stacked. Border is similar to button,
+/// hopefully indicating a "tappable" element. But the border is rounded,
+/// not capsule, hopefully indicating this is different from a button.
+struct BookTextFieldModifier: ViewModifier {
+	@ScaledMetric(relativeTo: .body) private var border = BookStyle.border
+	@ScaledMetric(relativeTo: .body) private var padding = BookStyle.padding
+	
+	func body(content: Content) -> some View {
+		content
+			.padding(EdgeInsets(top: self.padding, leading: self.padding * 2, bottom: self.padding, trailing: self.padding * 2))
+			.bookViewFrame()
+			.background(.background.opacity(0.75),
+						in: RoundedRectangle(cornerRadius: 8.0))
+			.overlay {
+				RoundedRectangle(cornerRadius: 8.0)
+					.stroke(Color(.accent), lineWidth: self.border)
+			}
+	}
+}
+
+extension View {
+	/// Apply the "bookmind text field" apperance. Indicates tappable,
+	/// but slightly different from buttons and pickers.
+	func bookTextFieldStyle() -> some View {
+		modifier(BookTextFieldModifier())
+	}
+}
+
+#Preview {
+	ZStack {
+		Color(.systemIndigo)
+			.ignoresSafeArea()
+		VStack {
+			TextField("ISBN", text: .constant("444-44444-444-4"))
+				.bookTextFieldStyle()
+			TextField("First Name", text: .constant(""))
+				.bookTextFieldStyle()
+			TextField("Last Name", text: .constant(""))
+				.bookTextFieldStyle()
+			TextField("Title", text: .constant("Dune"))
+				.bookTextFieldStyle()
+		}
+			.padding()
+	}
+}


### PR DESCRIPTION
Added first and last name text fields, shown when edit is tapped on the author screen. Changed author name (full name) property to a derived property, now only calculated from first and last name. Updated constructor to use the name we get from open library just the once to derive first and last names, then we won't even store this.

Added a custom text field appearance. Applied that appearance to the new first and last name text fields, as well as the fairly new search text field.