### PR TITLE
24 added several scanning fixes

### DIFF
--- a/Bookmind/Entity/Book.swift
+++ b/Bookmind/Entity/Book.swift
@@ -21,8 +21,9 @@ struct Book {
 	
 	/// If there is a book with the specified isbn stored in swift data,
 	/// return that book, otherwise return nil.
-	@MainActor static func fetch(isbn: String, storage: StorageModel) -> Book? {
-		guard let edition = Edition.fetch(isbn: isbn, storage: storage) else {
+	@MainActor static func fetch(isbn: ISBN, storage: StorageModel) -> Book? {
+		guard let isbn13 = isbn.digitString13 else { return nil }
+		guard let edition = Edition.fetch(isbn: isbn13, storage: storage) else {
 			return nil
 		}
 		guard let work = edition.work else { return nil }

--- a/Bookmind/Scan/ISBN.swift
+++ b/Bookmind/Scan/ISBN.swift
@@ -9,34 +9,72 @@ import Foundation
 
 /// ISBN is used to select valid ISBN numbers from scanned string input.
 /// The "better" this check is, the less requests we send to fetch book details,
-/// and the less processing we do while the scanner is running. We should probably
-/// add that checksum calculation.
+/// and the less processing we do while the scanner is running.
 struct ISBN: Equatable {
+	/// The ISBN number as scanned, including -'s but not a prefix.
+	/// Mostly for debug purposes.
 	let displayString: String
+	/// The ISBN digits only, i.e. -'s and prefix removed. Used for
+	/// openlibrary edition lookups. We convert 9 digit SBN's to 10
+	/// digit ISBN's as some lookups can fail if we don't.
 	let digitString: String
-	
-	private static let validISBNCharacters = CharacterSet(charactersIn: "01234567890-xX")
-	
+	/// The digits in ISBN13 format, used as a unique identifier to
+	/// store editions.
+	var digitString13: String? {
+		if self.digitString.count == 13 { return self.digitString }
+		
+		var sbn: String
+		if self.digitString.count == 9 {
+			sbn = "9780" + self.digitString
+		} else if self.digitString.count == 10 {
+			sbn = "978" + self.digitString
+		} else {
+			return nil
+		}
+		// remove check digit
+		sbn.removeLast()
+		
+		// calculate new check digit
+		let multipliers = [1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3]
+		let digits: [Int] = sbn.compactMap { $0.wholeNumberValue }
+		guard digits.count == 12 else { return nil }
+		
+		var checkSum = 0
+		for index in 0..<digits.count {
+			checkSum += digits[index] * multipliers[index]
+		}
+		let remainder = checkSum % 10
+		let checkDigit = remainder == 0 ? 0 : 10 - remainder
+		
+		return sbn + String(checkDigit)
+	 }
+
+	private static let validISBN10Characters = CharacterSet(charactersIn: "01234567890xX")
+	private static let validISBN13Characters = CharacterSet(charactersIn: "01234567890")
+
 	init?(_ string: String) {
 		guard let displayString = Self.firstCode(in: string) else {
 			return nil
 		}
 
 		self.displayString = displayString
-		let characters = CharacterSet(charactersIn: displayString)
-		guard characters.isSubset(of: Self.validISBNCharacters) else {
-			return nil
-		}
-		
 		let components = displayString.components(separatedBy: "-")
-		let digits = components.joined()
-		guard digits.count == 9 || digits.count == 10 || digits.count == 13 else {
+		var digits = components.joined()
+		guard digits.count == 9 || digits.count == 10 || digits.count == 13 else { return nil }
+
+		let validDigits = digits.count == 10 ? Self.validISBN10Characters : Self.validISBN13Characters
+		let characters = CharacterSet(charactersIn: digits)
+		guard characters.isSubset(of: validDigits) else {
 			return nil
 		}
-		
+
+		if digits.count == 9 {
+			digits = "0" + digits
+		}
 		self.digitString = digits
 	}
-	
+
+	/// Return the first ISBN code found in string.
 	private static func firstCode(in string: String) -> String? {
 		guard string.count >= 9 else { return nil }
 		
@@ -50,16 +88,6 @@ struct ISBN: Equatable {
 		return nil
 	}
 	
-	private static func firstPrefix(in words: [String]) -> Int? {
-		// yeah this is a bit ridiculous for if/else cases
-		for prefix in ["ISBN-13:", "ISBN-10:", "ISBN:", "ISBN", "SBN"] {
-			if let index = words.firstIndex(of: prefix) {
-				return index
-			}
-		}
-		return nil
-	}
-	
 	struct Preview {
 		static let prefix = ISBN("text before isbn number SBN 425-03071-7")
 		static let suffix = ISBN("SBN 425-03071-7 text after isbn number")
@@ -69,27 +97,44 @@ struct ISBN: Equatable {
 		static let isbnX = ISBN("ISBN 1-55192-756-X")
 		static let isbn10 = ISBN("ISBN 0-441-78754-1")
 		static let isbn13 = ISBN("ISBN 978-3-16-148410-0")
-		static let isbn_10 = ISBN("ISBN-10: 0-7582-8393-8")
-		static let isbn_13 = ISBN("ISBN-13: 978-0-7783-3027-1")
+		static let isbnDash10 = ISBN("ISBN-10 0-7582-8393-8")
+		static let isbnDash13 = ISBN("ISBN-13 978-0-7783-3027-1")
+		static let isbnDash10Colon = ISBN("ISBN-10: 0-7582-8393-8")
+		static let isbnDash13Colon = ISBN("ISBN-13: 978-0-7783-3027-1")
+		static let isbnSpace10 = ISBN("ISBN 10 0-7582-8393-8")
+		static let isbnSpace13 = ISBN("ISBN 13 978-0-7783-3027-1")
+		static let isbnSpace10Colon = ISBN("ISBN 10: 0-7582-8393-8")
+		static let isbnSpace13Colon = ISBN("ISBN 13: 978-0-7783-3027-1")
 		static let copyright = ISBN("ISBN: 0-441-78754-1")
 	}
 }
 
 private extension Array where Element == String {
+	/// Return the first code (digits and dashes) in the array. Here we check for
+	/// a keyword with a space between it and the code, i.e ISBN: 0-441-78754-1
+	/// or even the sneakier "ISBN 10: 0-7582-8393-8" with two spaces.
 	func firstCodeAfterKeyword() -> String? {
-		for keyword in ["ISBN-13:", "ISBN-10:", "ISBN:", "ISBN", "SBN"] {
+		guard self.count > 1 else { return nil }
+		
+		if let index = self.firstIndex(of: "ISBN") {
+			var code = self[index + 1]
+			if ["13", "10", "13:", "10:"].contains(code) && self.count > 2 {
+				code = self[index + 2]
+			}
+			return code
+		}
+		
+		for keyword in ["ISBN-13:", "ISBN-10:", "ISBN-13", "ISBN-10", "ISBN:", "SBN"] {
 			if let index = self.firstIndex(of: keyword) {
-				if self.count > index + 1 {
-					let code = self[index + 1]
-					if code.count > 9 || code.count < 20 {
-						return code
-					}
-				}
+				return self[index + 1]
 			}
 		}
+		
 		return nil
 	}
 	
+	/// Return the first code (digits and dashes) in the array. Here we check for a
+	/// prefix stuck to the code without spaces e.g. SBN-425-03585-9.
 	func firstCodeWithPrefix() -> String? {
 		for prefix in ["SBN-"] {
 			if let word = self.first(where: { $0.hasPrefix(prefix) }) {

--- a/Bookmind/Scan/ScanScreen.swift
+++ b/Bookmind/Scan/ScanScreen.swift
@@ -75,7 +75,7 @@ struct ScanScreen: View {
 	
 	private func scanModelChanged() {
 		if case .found(let isbn) = self.scanModel.state {
-			if let stored = Book.fetch(isbn: isbn.digitString, storage: self.storage) {
+			if let stored = Book.fetch(isbn: isbn, storage: self.storage) {
 				self.searchModel.result = .found(stored)
 				return
 			}

--- a/Bookmind/Search/SearchScreen.swift
+++ b/Bookmind/Search/SearchScreen.swift
@@ -74,7 +74,7 @@ struct SearchScreen: View {
 	
 	private func searchTapped() {
 		if let isbn = ISBN("ISBN " + self.searchText) {
-			if let stored = Book.fetch(isbn: self.searchText, storage: self.storage) {
+			if let stored = Book.fetch(isbn: isbn, storage: self.storage) {
 				self.searchModel.result = .found(stored)
 				return
 			}

--- a/BookmindTests/ISBNTests.swift
+++ b/BookmindTests/ISBNTests.swift
@@ -42,25 +42,25 @@ final class ISBNTests: XCTestCase {
 	func testSuffix() {
 		let isbn = ISBN.Preview.prefix
 		XCTAssertEqual(isbn?.displayString, "425-03071-7")
-		XCTAssertEqual(isbn?.digitString, "425030717")
+		XCTAssertEqual(isbn?.digitString, "0425030717")
 	}
 	
 	func testPrefix() {
 		let isbn = ISBN.Preview.suffix
 		XCTAssertEqual(isbn?.displayString, "425-03071-7")
-		XCTAssertEqual(isbn?.digitString, "425030717")
+		XCTAssertEqual(isbn?.digitString, "0425030717")
 	}
 	
 	func testSBN() {
 		let isbn = ISBN.Preview.sbn
 		XCTAssertEqual(isbn?.displayString, "425-03071-7")
-		XCTAssertEqual(isbn?.digitString, "425030717")
+		XCTAssertEqual(isbn?.digitString, "0425030717")
 	}
 	
 	func testSBN_() {
 		let isbn = ISBN.Preview.sbn_
 		XCTAssertEqual(isbn?.displayString, "425-03585-9")
-		XCTAssertEqual(isbn?.digitString, "425035859")
+		XCTAssertEqual(isbn?.digitString, "0425035859")
 	}
 	
 	func testISBNX() {
@@ -78,7 +78,19 @@ final class ISBNTests: XCTestCase {
 		XCTAssertEqual(isbn?.displayString, "0-441-78754-1")
 		XCTAssertEqual(isbn?.digitString, "0441787541")
 		
-		isbn = ISBN.Preview.isbn_10
+		isbn = ISBN.Preview.isbnDash10
+		XCTAssertEqual(isbn?.displayString, "0-7582-8393-8")
+		XCTAssertEqual(isbn?.digitString, "0758283938")
+		
+		isbn = ISBN.Preview.isbnDash10Colon
+		XCTAssertEqual(isbn?.displayString, "0-7582-8393-8")
+		XCTAssertEqual(isbn?.digitString, "0758283938")
+
+		isbn = ISBN.Preview.isbnSpace10
+		XCTAssertEqual(isbn?.displayString, "0-7582-8393-8")
+		XCTAssertEqual(isbn?.digitString, "0758283938")
+		
+		isbn = ISBN.Preview.isbnSpace10Colon
 		XCTAssertEqual(isbn?.displayString, "0-7582-8393-8")
 		XCTAssertEqual(isbn?.digitString, "0758283938")
 	}
@@ -88,7 +100,19 @@ final class ISBNTests: XCTestCase {
 		XCTAssertEqual(isbn?.displayString, "978-3-16-148410-0")
 		XCTAssertEqual(isbn?.digitString, "9783161484100")
 		
-		isbn = ISBN.Preview.isbn_13
+		isbn = ISBN.Preview.isbnDash13
+		XCTAssertEqual(isbn?.displayString, "978-0-7783-3027-1")
+		XCTAssertEqual(isbn?.digitString, "9780778330271")
+		
+		isbn = ISBN.Preview.isbnDash13Colon
+		XCTAssertEqual(isbn?.displayString, "978-0-7783-3027-1")
+		XCTAssertEqual(isbn?.digitString, "9780778330271")
+
+		isbn = ISBN.Preview.isbnSpace13
+		XCTAssertEqual(isbn?.displayString, "978-0-7783-3027-1")
+		XCTAssertEqual(isbn?.digitString, "9780778330271")
+		
+		isbn = ISBN.Preview.isbnSpace13Colon
 		XCTAssertEqual(isbn?.displayString, "978-0-7783-3027-1")
 		XCTAssertEqual(isbn?.digitString, "9780778330271")
 	}
@@ -97,5 +121,17 @@ final class ISBNTests: XCTestCase {
 		let isbn = ISBN.Preview.copyright
 		XCTAssertEqual(isbn?.displayString, "0-441-78754-1")
 		XCTAssertEqual(isbn?.digitString, "0441787541")
+	}
+	
+	func testDigitString13() {
+		XCTAssertEqual(ISBN("ISBN 0811853462")?.digitString13, "9780811853460")
+		//	https://openlibrary.org/isbn/425030717.json
+		XCTAssertEqual(ISBN.Preview.sbn?.digitString13, "9780425030714")
+		//	https://openlibrary.org/isbn/000653192x.json
+		XCTAssertEqual(ISBN.Preview.isbnx?.digitString13, "9780006531920")
+		//	https://openlibrary.org/isbn/155192756X.json
+		XCTAssertEqual(ISBN.Preview.isbnX?.digitString13, "9781551927565")
+		//	https://openlibrary.org/isbn/0441787541.json
+		XCTAssertEqual(ISBN.Preview.isbn10?.digitString13, "9780441787548")
 	}
 }


### PR DESCRIPTION
Fixes #24,  fixes #11. Added support and tests for a few more variations of ISBN with spaces and colons. Discovered a fix for some older 9 digit sbns which were not found: just convert to 10 digits.

Added another fix for a weird bug with using saved results. Since editions have always been saved with the isbn 13 from lookup, a 10 digit id manually entered in the search screen is treated as a new book. Fixed this by always converted to 13 digits before a local lookup.