### PR TITLE
Fixes #35 add isbn example to search field prompt text

### DIFF
--- a/Bookmind/Scan/ScanScreen.swift
+++ b/Bookmind/Scan/ScanScreen.swift
@@ -74,14 +74,16 @@ struct ScanScreen: View {
 	}
 	
 	private func scanModelChanged() {
-		if case .found(let isbn) = self.scanModel.state {
-			if let stored = Book.fetch(isbn: isbn, storage: self.storage) {
-				self.searchModel.result = .found(stored)
-				return
-			}
-
-			self.searchModel.search(for: isbn)
+		guard case .found(let isbn) = self.scanModel.state else {
+			return
 		}
+		
+		if let stored = Book.fetch(isbn: isbn, storage: self.storage) {
+			self.searchModel.result = .found(stored)
+			return
+		}
+
+		self.searchModel.search(for: isbn)
 	}
 }
 

--- a/Bookmind/Search/BookSearch.swift
+++ b/Bookmind/Search/BookSearch.swift
@@ -25,13 +25,14 @@ class BookSearch {
 	// a published state property it is fantastic to be able to convey
 	// as many states as necessary, including .none for a nil value.
 	enum Result: Equatable {
+		case invalid
 		/// Waiting on the response for a book detail request for a scanned ISBN.
 		case searching(String)
 		/// Found details for a book matching the scanned ISBN.
 		case found(Book)
 		/// No book was found matching the scanned ISBN.
 		/// Should distinguish general network errors here...
-		case failed(String)		
+		case failed(String)
 	}
 	
 	struct Preview {

--- a/Bookmind/Search/SearchProgressView.swift
+++ b/Bookmind/Search/SearchProgressView.swift
@@ -40,7 +40,7 @@ struct SearchProgressView: View {
 					BookButtonLabel(book: Binding($foundBook)!)
 				}
 			} else if let message = self.message {
-				Text(message)
+				Text(.init(message))
 					.bookGroupStyle()
 					.multilineTextAlignment(.center)
 			} else {
@@ -63,8 +63,10 @@ struct SearchProgressView: View {
 		return switch self.result {
 		case .searching(let isbn):
 			"Searching for ISBN \(isbn)"
+		case .invalid:
+			"Please type a valid ISBN 10 or 13 code such as 0-5555-5555-X or 978-0-5555-5555-1"
 		case .failed(let isbn):
-			"Could not find ISBN \(isbn)"
+			"Could not find ISBN \(isbn) on **[Open Library](https://openlibrary.org)**. You can sign up and add it! Or, soon, tap Add to type in the details for that book."
 		default:
 			nil
 		}

--- a/Bookmind/Search/SearchScreen.swift
+++ b/Bookmind/Search/SearchScreen.swift
@@ -53,7 +53,7 @@ struct SearchScreen: View {
 					SearchProgressView(result: self.$searchModel.result,
 									   router: self.router)
 				}
-				TextField("ISBN", text: self.$searchText)
+				TextField("ISBN (e.g. 0123456781)", text: self.$searchText)
 					.bookTextFieldStyle()
 					.keyboardType(.numbersAndPunctuation)
 					.autocorrectionDisabled()
@@ -73,14 +73,17 @@ struct SearchScreen: View {
 	}
 	
 	private func searchTapped() {
-		if let isbn = ISBN("ISBN " + self.searchText) {
-			if let stored = Book.fetch(isbn: isbn, storage: self.storage) {
-				self.searchModel.result = .found(stored)
-				return
-			}
-			
-			self.searchModel.search(for: isbn)
+		guard let isbn = ISBN("ISBN " + self.searchText) else {
+			self.searchModel.result = .invalid
+			return
 		}
+		
+		if let stored = Book.fetch(isbn: isbn, storage: self.storage) {
+			self.searchModel.result = .found(stored)
+			return
+		}
+		
+		self.searchModel.search(for: isbn)
 	}
 }
 


### PR DESCRIPTION
The search screen text field now includes an example isbn in its prompt text. Hopefully it demonstrates that you don't *need* to type the dashes, although you still can.

Added an "Invalid" state to the search model. The search screen sets this state when the user types a number that is not an isbn. The search screen will show a message about valid isbn format.

Updated the search model message for "not found". The message now includes a link to open library and lets the user know they can add the book there. The message also includes a teaser about a manual entry screen.