### PR TITLE
Fixes #36 delete author after deleting their last book

### DIFF
--- a/Bookmind/BookmindApp.swift
+++ b/Bookmind/BookmindApp.swift
@@ -20,11 +20,12 @@ struct BookmindApp: App {
     var body: some Scene {
         WindowGroup {
 			NavigationStack(path: self.$router.path) {
-				HomeScreen(router: self.router)
+				HomeScreen()
 			}
 			.modelContainer(self.storage.container)
 			.environmentObject(self.storage)
 			.environmentObject(self.covers)
+			.environmentObject(self.router)
         }
     }
 }

--- a/Bookmind/Browse/AuthorScreen.swift
+++ b/Bookmind/Browse/AuthorScreen.swift
@@ -70,6 +70,11 @@ struct AuthorScreen: View {
 		.toolbar {
 			EditButton()
 		}
+		.onAppear() {
+			if self.author.books.isEmpty {
+				self.dismiss()
+			}
+		}
 	}
 	
 	private func delete(at offsets: IndexSet) {

--- a/Bookmind/Browse/WorkScreen.swift
+++ b/Bookmind/Browse/WorkScreen.swift
@@ -78,9 +78,11 @@ struct WorkScreen: View {
 			for author in authors {
 				author.books.removeAll(where: { $0 == self.work })
 			}
+			let bookless = authors.filter { $0.books.isEmpty }
+			if !bookless.isEmpty {
+				self.storage.delete(bookless)
+			}
 		}
-
-		// let the user decide if they want to keep the author or not
 	}
 }
 

--- a/Bookmind/HomeScreen.swift
+++ b/Bookmind/HomeScreen.swift
@@ -14,9 +14,8 @@ import SwiftUI
 struct HomeScreen: View {
 	/// A query used to decide if we should show the welcome text.
 	@Query var authors: [Author]
-	/// A collection of bindings and flags that allow navigation between
-	/// search screens.
-	@ObservedObject var router: SearchRouter
+	/// An environment object used to navigate between search screens.
+	@EnvironmentObject private var router: SearchRouter
 	/// The height class environment variable, used in screen layout.
 	@Environment(\.verticalSizeClass) private var heightClass
 	/// Updated by the editable modifier when edit mode changes.
@@ -62,13 +61,13 @@ struct HomeScreen: View {
 			.animation(.smooth, value: self.isEditing)
 			.editable(self.$isEditing)
 			.fullScreenCover(isPresented: self.$router.isScanning) {
-				ScanScreen(router: self.router)
+				ScanScreen()
 			}
 			.navigationDestination(for: SearchRouter.Search.self) { _ in 
-				SearchScreen(router: self.router)
+				SearchScreen()
 			}
 			.navigationDestination(for: Book.self) { book in
-				InsertBookScreen(router: self.router, book: book)
+				InsertBookScreen(book: book)
 			}
 		}
 		.navigationBarTitleDisplayMode(.large)
@@ -78,15 +77,17 @@ struct HomeScreen: View {
 
 #Preview {
 	NavigationStack {
-		HomeScreen(router: SearchRouter())
+		HomeScreen()
 			.modelContainer(StorageModel().container)
 	}
+	.environmentObject(SearchRouter())
 }
 
 #Preview {
 	NavigationStack {
-		HomeScreen(router: SearchRouter())
+		HomeScreen()
 	}
 	.modelContainer(StorageModel.preview.container)
 	.environmentObject(CoverModel())
+	.environmentObject(SearchRouter())
 }

--- a/Bookmind/InsertBookScreen.swift
+++ b/Bookmind/InsertBookScreen.swift
@@ -10,12 +10,10 @@ import SwiftUI
 
 /// InsertBookScreen displays a book found by search or scan.
 struct InsertBookScreen: View {
-	/// A binding used to navigate between search screens. When the user
-	/// selects a book search result, we set the "inserting" book and the
-	/// home screen will push the insert book screen.
-	@ObservedObject var router: SearchRouter
 	/// The book to display. The user may edit rating and read state.
 	@State var book: Book
+	/// An environment object used to navigate between search screens.
+	@EnvironmentObject private var router: SearchRouter
 	/// The height class environment variable, used in screen layout.
 	@Environment(\.verticalSizeClass) private var heightClass
 	
@@ -40,13 +38,13 @@ struct InsertBookScreen: View {
 					if !self.isStored {
 						Button(action: {
 							_ = self.storage.insert(book: self.book)
-							self.router.path.removeLast(self.router.path.count)
+							self.router.popToRoot()
 						}, label: {
 							Label("Save", systemImage: "plus.circle.fill")
 								.bookButtonStyle()
 						})
 						Button(action: {
-							self.router.path.removeLast(self.router.path.count)
+							self.router.popToRoot()
 						}, label: {
 							Label("Cancel", systemImage: "minus.diamond.fill")
 								.bookButtonStyle()
@@ -64,23 +62,26 @@ struct InsertBookScreen: View {
 #Preview {
 	let storage = StorageModel(preview: true)
 	let book = storage.insert(book: Book.Preview.quiet)
-	return InsertBookScreen(router: SearchRouter(), book: book)
+	return InsertBookScreen(book: book)
 		.modelContainer(storage.container)
 		.environmentObject(CoverModel())
+		.environmentObject(storage)
 }
 
 #Preview {
 	let storage = StorageModel(preview: true)
 	let book = storage.insert(book: Book.Preview.legend)
-	return InsertBookScreen(router: SearchRouter(), book: book)
+	return InsertBookScreen(book: book)
 		.modelContainer(storage.container)
 		.environmentObject(CoverModel())
+		.environmentObject(storage)
 }
 
 #Preview {
 	let storage = StorageModel(preview: true)
 	let book = storage.insert(book: Book.Preview.dorsai)
-	return InsertBookScreen(router: SearchRouter(), book: book)
+	return InsertBookScreen(book: book)
 		.modelContainer(storage.container)
 		.environmentObject(CoverModel())
+		.environmentObject(storage)
 }

--- a/Bookmind/Scan/ScanScreen.swift
+++ b/Bookmind/Scan/ScanScreen.swift
@@ -19,12 +19,8 @@ import SwiftUI
 /// The scan screen also has a search model. When we detect something we're
 /// reasonably sure is an ISBN, we start a search. The search result is shown
 /// in our search progress view, including a found book. If the user taps the
-/// book we pass that back to the home screen via our selected book binding.
+/// book we use the router to show the insert screen.
 struct ScanScreen: View {
-	/// A binding used to navigate between search screens. When the user
-	/// selects a book search result, we set the "inserting" book and the
-	/// home screen will push the insert book screen.
-	@ObservedObject var router: SearchRouter
 	/// A model tracking the scanner. We use its published state to
 	/// provide feedback on scan progress.
 	@StateObject var scanModel = ScanModel()
@@ -32,6 +28,8 @@ struct ScanScreen: View {
 	/// and search screens. We *could* make this an environment object
 	/// but as with the scanner it's safer and simpler to start fresh.
 	@StateObject var searchModel = SearchModel()
+	/// An environment object used to navigate between search screens.
+	@EnvironmentObject private var router: SearchRouter
 	/// A model providing swift data entity specific convenience methods.
 	@EnvironmentObject private var storage: StorageModel
 
@@ -47,8 +45,7 @@ struct ScanScreen: View {
 			VStack() {
 				Spacer()
 				if self.searchModel.result != nil {
-					SearchProgressView(result: self.$searchModel.result,
-									   router: self.router)
+					SearchProgressView(result: self.$searchModel.result)
 				} else {
 					Text(self.scanModel.description)
 						.bookGroupStyle()
@@ -89,28 +86,28 @@ struct ScanScreen: View {
 
 #Preview {
 	VStack() {
-		ScanScreen(router: SearchRouter())
+		ScanScreen()
 	}
 }
 
 #Preview {
 	VStack {
-		ScanScreen(router: SearchRouter(), scanModel: ScanModel.Preview.foundText)
+		ScanScreen(scanModel: ScanModel.Preview.foundText)
 	}
 }
 
 #Preview {
 	VStack() {
-		ScanScreen(router: SearchRouter(), scanModel: ScanModel.Preview.failed)
-		ScanScreen(router: SearchRouter(), scanModel: ScanModel.Preview.found)
+		ScanScreen(scanModel: ScanModel.Preview.failed)
+		ScanScreen(scanModel: ScanModel.Preview.found)
 	}
 }
 
 #Preview {
 	NavigationStack {
 		VStack {
-			ScanScreen(router: SearchRouter(), searchModel: SearchModel.Preview.searching)
-			ScanScreen(router: SearchRouter(), searchModel: SearchModel.Preview.quiet)
+			ScanScreen(searchModel: SearchModel.Preview.searching)
+			ScanScreen(searchModel: SearchModel.Preview.quiet)
 		}
 	}
 	.environmentObject(CoverModel())
@@ -119,8 +116,8 @@ struct ScanScreen: View {
 #Preview {
 	NavigationStack {
 		VStack {
-			ScanScreen(router: SearchRouter(), searchModel: SearchModel.Preview.failed)
-			ScanScreen(router: SearchRouter(), searchModel: SearchModel.Preview.legend)
+			ScanScreen(searchModel: SearchModel.Preview.failed)
+			ScanScreen(searchModel: SearchModel.Preview.legend)
 		}
 	}
 	.environmentObject(CoverModel())

--- a/Bookmind/Search/SearchProgressView.swift
+++ b/Bookmind/Search/SearchProgressView.swift
@@ -21,7 +21,7 @@ struct SearchProgressView: View {
 	/// A binding used to navigate between search screens. When the user
 	/// selects a book search result, we set the "inserting" book and the
 	/// home screen will push the insert book screen.
-	@ObservedObject var router: SearchRouter
+	@EnvironmentObject private var router: SearchRouter
 
 	/// A binding for a found book, updated when the search model
 	/// finds results for a scanned ISBN. Used to show or hide the
@@ -84,18 +84,12 @@ struct SearchProgressView: View {
 		Color(.systemIndigo)
 			.ignoresSafeArea()
 		VStack(spacing: 16.0) {
-			SearchProgressView(result: .constant(nil),
-							   router: SearchRouter())
-			SearchProgressView(result: .constant(BookSearch.Preview.failed),
-							   router: SearchRouter())
-			SearchProgressView(result: .constant(BookSearch.Preview.searching),
-							   router: SearchRouter())
-			SearchProgressView(result: .constant(BookSearch.Preview.quiet),
-							   router: SearchRouter())
-			SearchProgressView(result: .constant(BookSearch.Preview.legend),
-							   router: SearchRouter())
-			SearchProgressView(result: .constant(BookSearch.Preview.dorsai),
-							   router: SearchRouter())
+			SearchProgressView(result: .constant(nil))
+			SearchProgressView(result: .constant(BookSearch.Preview.failed))
+			SearchProgressView(result: .constant(BookSearch.Preview.searching))
+			SearchProgressView(result: .constant(BookSearch.Preview.quiet))
+			SearchProgressView(result: .constant(BookSearch.Preview.legend))
+			SearchProgressView(result: .constant(BookSearch.Preview.dorsai))
 		}
 		.padding()
 	}

--- a/Bookmind/Search/SearchScreen.swift
+++ b/Bookmind/Search/SearchScreen.swift
@@ -29,10 +29,6 @@ import SwiftUI
 /// before opening the detail screen. We probably want a save button on
 /// the book detail screen, and to only insert then. 
 struct SearchScreen: View {
-	/// A binding used to navigate between search screens. When the user
-	/// selects a book search result, we set the "inserting" book and the
-	/// home screen will push the insert book screen.
-	@ObservedObject var router: SearchRouter
 	/// A model used to search for editions by ISBN. Shared by the scan
 	/// and search screens. We *could* make this an environment object
 	/// but as with the scanner it's safer and simpler to start fresh.
@@ -50,8 +46,7 @@ struct SearchScreen: View {
 			VStack {
 				Spacer()
 				if self.searchModel.result != nil {
-					SearchProgressView(result: self.$searchModel.result,
-									   router: self.router)
+					SearchProgressView(result: self.$searchModel.result)
 				}
 				TextField("ISBN (e.g. 0123456781)", text: self.$searchText)
 					.bookTextFieldStyle()
@@ -89,26 +84,26 @@ struct SearchScreen: View {
 
 #Preview {
 	NavigationStack {
-		SearchScreen(router: SearchRouter(), searchModel: SearchModel.Preview.searching)
+		SearchScreen(searchModel: SearchModel.Preview.searching)
 	}
 }
 
 #Preview {
 	NavigationStack {
-		SearchScreen(router: SearchRouter(), searchModel: SearchModel.Preview.failed)
+		SearchScreen(searchModel: SearchModel.Preview.failed)
 	}
 }
 
 #Preview {
 	NavigationStack {
-		SearchScreen(router: SearchRouter(), searchModel: SearchModel.Preview.quiet)
+		SearchScreen(searchModel: SearchModel.Preview.quiet)
 	}
 	.environmentObject(CoverModel())
 }
 
 #Preview {
 	NavigationStack {
-		SearchScreen(router: SearchRouter(), searchModel: SearchModel.Preview.legend)
+		SearchScreen(searchModel: SearchModel.Preview.legend)
 	}
 	.environmentObject(CoverModel())
 }

--- a/Bookmind/SearchRouter.swift
+++ b/Bookmind/SearchRouter.swift
@@ -18,6 +18,10 @@ final class SearchRouter: ObservableObject {
 	/// A binding flag used to show and hide the scan screen.
 	@Published var isScanning = false
 	
+	func popToRoot() {
+		self.path.removeLast(self.path.count)
+	}
+	
 	/// A stub type used to push the search screen onto a navigations stack.
 	/// We may need to add a similar type for an inserting book if we ever
 	/// push another kind of book screen onto the stack. 


### PR DESCRIPTION
This is already implemented on the author screen. But now we also have the book screen delete the author. We rely on the author screen to check it has no books and pop itself... this may be problematic later.

Snuck in a surprisingly large refactor where we moved the search router to an environment variable. Big change but simplified a ton of code.