### PR TITLE
Fixes #40 add book title edit text field

### DIFF
--- a/Bookmind.xcodeproj/project.pbxproj
+++ b/Bookmind.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		EE8F41B02C3048B1007A22F5 /* SearchRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8F41AF2C3048B1007A22F5 /* SearchRouter.swift */; };
 		EE8F41B52C3447C0007A22F5 /* BookTextFieldModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8F41B42C3447C0007A22F5 /* BookTextFieldModifier.swift */; };
 		EE90189A2C0FB84100B6990A /* WorkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE9018992C0FB84100B6990A /* WorkTests.swift */; };
+		EE9032E82C39761900D19EA8 /* AuthorLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE9032E72C39761900D19EA8 /* AuthorLabel.swift */; };
 		EEBB7CE52C17AD6E00C96389 /* Book.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBB7CE42C17AD6E00C96389 /* Book.swift */; };
 		EEC762A32C1338650074066E /* BookStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC762A22C1338650074066E /* BookStyle.swift */; };
 		EEC762A52C1344100074066E /* OwnStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC762A42C1344100074066E /* OwnStateView.swift */; };
@@ -139,6 +140,7 @@
 		EE8F41AF2C3048B1007A22F5 /* SearchRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRouter.swift; sourceTree = "<group>"; };
 		EE8F41B42C3447C0007A22F5 /* BookTextFieldModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookTextFieldModifier.swift; sourceTree = "<group>"; };
 		EE9018992C0FB84100B6990A /* WorkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkTests.swift; sourceTree = "<group>"; };
+		EE9032E72C39761900D19EA8 /* AuthorLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorLabel.swift; sourceTree = "<group>"; };
 		EEBB7CE42C17AD6E00C96389 /* Book.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Book.swift; sourceTree = "<group>"; };
 		EEC762A22C1338650074066E /* BookStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookStyle.swift; sourceTree = "<group>"; };
 		EEC762A42C1344100074066E /* OwnStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OwnStateView.swift; sourceTree = "<group>"; };
@@ -195,6 +197,7 @@
 		74471AF02B669A2C00400686 /* Browse */ = {
 			isa = PBXGroup;
 			children = (
+				EE9032E72C39761900D19EA8 /* AuthorLabel.swift */,
 				748D42FF2B6958E900D34AED /* AuthorScreen.swift */,
 				EEC762AA2C1368A00074066E /* CoverBackgroundView.swift */,
 				EEC762AC2C137EAC0074066E /* CoverView.swift */,
@@ -495,6 +498,7 @@
 				74B8DF832B5C295200D2F818 /* OpenLibraryAuthor.swift in Sources */,
 				74B503042B44554B0092B0E4 /* ScanView.swift in Sources */,
 				EEC762B12C13AF610074066E /* BookButtonLabel.swift in Sources */,
+				EE9032E82C39761900D19EA8 /* AuthorLabel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Bookmind/Browse/AuthorLabel.swift
+++ b/Bookmind/Browse/AuthorLabel.swift
@@ -1,0 +1,33 @@
+//
+//  AuthorLabel.swift
+//  Bookmind
+//
+//  Created by Dave Ruest on 2024-07-06.
+//
+
+import SwiftUI
+
+/// AuthorLabel shows a formatted author name and book count in an
+/// hstack. This is used in a couple places, so moving that code here
+/// simplifies the calling screens. 
+struct AuthorLabel: View {
+	let author: Author
+	
+	var body: some View {
+		HStack {
+			Text("\(author.firstName) **\(author.lastName)**")
+			Spacer()
+			Text("\(author.books.count)")
+		}
+		.bookViewFrame()
+	}
+}
+
+#Preview {
+	VStack {
+		AuthorLabel(author: Author.Preview.cain)
+		AuthorLabel(author: Author.Preview.dickson)
+		AuthorLabel(author: Author.Preview.gemmell)
+	}
+	.padding()
+}

--- a/Bookmind/Browse/AuthorScreen.swift
+++ b/Bookmind/Browse/AuthorScreen.swift
@@ -11,15 +11,21 @@ import SwiftUI
 /// AuthorScreen displays the list of books for a specific author.
 struct AuthorScreen: View {
 	/// The author whose name and works will be shown.
-	@State var author: Author
+	@State private var author: Author
 	/// Updated by the editable modifier when edit mode changes.
-	@State var isEditing = false
+	/// Public to enable edit layout previews.
+	@State private var isEditing = false
 	/// A model providing swift data entity specific convenience methods.
 	@EnvironmentObject private var storage: StorageModel
 	/// The dismiss environment variable, used to close the screen if
 	/// we delete the last edition of a work and the work.
 	@Environment(\.dismiss) private var dismiss
 
+	init(author: Author, isEditing: Bool = false) {
+		self.author = author
+		self.isEditing = isEditing
+	}
+	
 	var body: some View {
 		ZStack {
 			Color(.background)

--- a/Bookmind/Browse/LibraryScreen.swift
+++ b/Bookmind/Browse/LibraryScreen.swift
@@ -23,12 +23,7 @@ struct LibraryScreen: View {
 				NavigationLink {
 					AuthorScreen(author: author)
 				} label: {
-					HStack {
-						Text("\(author.firstName) **\(author.lastName)**")
-						Spacer()
-						Text("\(author.books.count)")
-					}
-					.bookViewFrame()
+					AuthorLabel(author: author)
 				}
 				.bookListRowStyle()
 			}.onDelete(perform: delete)

--- a/Bookmind/Entity/Work.swift
+++ b/Bookmind/Entity/Work.swift
@@ -14,8 +14,7 @@ import UIKit
 /// restarts. The next big step for book will be cloud storage where
 /// the book will persist across devices.
 @Model final class Work: ObservableObject {
-	let title: String
-	let subtitle: String?
+	var title: String
 	/// The unique identifier for the author.
 	/// As this is an openlibrary author id, this ties our data rather
 	/// closely to openlibrary, but we may align the whole app that way.
@@ -28,13 +27,11 @@ import UIKit
 	/// Required for the "have I read this book" use case.
 	var readState = ReadState.none
 	
-	init(olid: String, title: String, subtitle: String? = nil,
-		 authors: [Author] = [], editions: [Edition] = [],
-		 readState: ReadState = .none)
+	init(olid: String, title: String, authors: [Author] = [],
+		 editions: [Edition] = [], readState: ReadState = .none)
 	{
 		self.olid = olid
 		self.title = title
-		self.subtitle = subtitle
 		self.authors = authors
 		self.editions = editions
 		self.readState = readState
@@ -43,10 +40,7 @@ import UIKit
 	struct Preview {
 		static var allBooks = [Self.quiet, Self.legend, Self.dorsai]
 		static var quiet: Work {
-			Work(olid: "/works/OL16484595W", title: "Quiet", 
-				 subtitle: "The Power of Introverts in a World That Can't Stop Talking",
-				 readState: .read
-			)
+			Work(olid: "/works/OL16484595W", title: "Quiet", readState: .read)
 		}
 		static var legend: Work {
 			Work(olid: "/works/OL21417594W", title: "Legend", readState: .read)

--- a/Bookmind/Search/OpenLibraryEdition.swift
+++ b/Bookmind/Search/OpenLibraryEdition.swift
@@ -19,7 +19,6 @@ struct OpenLibraryEdition: Decodable {
 	let isbn_13: [String]?
 	
 	let title: String
-	let subtitle: String?
 	let authors: [[String: String]]?
 	let works: [[String: String]]?
 	let covers: [Int]?
@@ -37,7 +36,7 @@ struct OpenLibraryEdition: Decodable {
 			// no work for the edition, treat as invalid for now
 			return nil
 		}
-		return Work(olid: olid, title: self.title, subtitle: self.subtitle)
+		return Work(olid: olid, title: self.title)
 	}
 
 	/// Return the open library url for edition data on the specified ISBN.

--- a/Bookmind/Style/BookListModifier.swift
+++ b/Bookmind/Style/BookListModifier.swift
@@ -13,6 +13,7 @@ import SwiftUI
 struct BookListModifier: ViewModifier {
 	func body(content: Content) -> some View {
 		content
+			.scrollContentBackground(.hidden)
 			.listStyle(.plain)
 			.listRowSeparatorTint(.accent)
 	}

--- a/BookmindTests/WorkTests.swift
+++ b/BookmindTests/WorkTests.swift
@@ -10,12 +10,6 @@ import SwiftData
 @testable import Bookmind
 
 final class WorkTests: XCTestCase {
-	func testSubtitle() {
-		XCTAssertNil(Work.Preview.dorsai.subtitle)
-		XCTAssertNil(Work.Preview.legend.subtitle)
-		XCTAssertNotNil(Work.Preview.quiet.subtitle)
-	}
-	
 	@MainActor func testAuthorNames() {
 		var book = Book.Preview.legend
 		XCTAssertEqual(book.work.authors.names, "")


### PR DESCRIPTION
A title text field now appears when the book screen edit button is tapped. The field is bound to the work title property, so changing the text updates the book title. Snuck in a list of authors that also appears when edit is tapped, read only for now. We'll add behavior to the list in the "fix author" ticket.

Added constructors to the work and author screens so that the author and work properties can be private, but also preview can show the editing layouts.

Removed subtitle property from work. The data I've seen has been inconsistent and low utility. Added an ISBN 13 label to the work screen.